### PR TITLE
fix(segmentsData): check added array for userIds

### DIFF
--- a/src/load-data.js
+++ b/src/load-data.js
@@ -23,10 +23,11 @@ export default function loadDataIntoLocalStorage ({ serializedData = {}, userId 
   })
 
   windowLocalStorage.setItem('SPLITIO.splits.usingSegments', usingSegmentsCount)
-  // segmentsData in an object where the property is the segment name and the pertaining value is an array of userIds
+  // segmentsData in an object where the property is the segment name and the pertaining value is a stringified object that contains the `added` array of userIds
   Object.keys(segmentsData).forEach(segmentName => {
     const key = `${userId}.SPLITIO.segment.${segmentName}`
-    if (segmentsData[segmentName].includes(userId) && windowLocalStorage.getItem(key) !== '1') {
+    const added = JSON.parse(segmentsData[segmentName]).added
+    if (added.includes(userId) && windowLocalStorage.getItem(key) !== '1') {
       windowLocalStorage.setItem(key, '1')
     }
   })

--- a/src/load-data.test.js
+++ b/src/load-data.test.js
@@ -59,8 +59,8 @@ describe('lib.load-data.loadDataIntoLocalStorage', () => {
     const userId = 'visitor_guid_1'
     const usingSegmentsCount = 2
     const segmentsData = {
-      segment_1: [userId, 'visitor_guid_2'],
-      segment_2: [userId, 'visitor_guid_3']
+      segment_1: `{ "name": "segment_1", "added": ["${userId}", "visitor_guid_2"] }`,
+      segment_2: `{ "name": "segment_2", "added": ["${userId}", "visitor_guid_3"] }`
     }
     localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
 


### PR DESCRIPTION
Re: https://github.com/godaddy/split-javascript-data-loader/pull/6/files#r358962320
This change fixes the logic for checking if the `userId` is in the `serializedData.segmentsData` parameter. `serializedData.segmentsData` will be an object where a string property maps to a stringified object (which contains the `added` property we want to check for the `userId`).
`serializedData.segmentsData` will look like this:
```js
segmentsData: {
"segment_1": "{ name: 'segment_1', added: ['test-visitor-1', 'test-visitor-2'] }"
}
```
The current logic assumes that the data would look something like this:
```js
segmentsData: {
"segment_1": ['test-visitor-1', 'test-visitor-2']
}
```