### PR TITLE
feat(loadDataIntoLocalStorage): add localStorageUserId param

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following option properties are available:
 | serializedData.splitsData         | An object of serialized split data you want to cache. (required) |
 | serializedData.usingSegmentsCount | The count of splits using segments. (required) |
 | userId                            | The user id that is a part of an experiment. Either a hashed shopperId or visitorGuid. (required) |
-| localStorageUserId                | The string that will represent the userId in the localStorage key related to segments data. (required) |
+| localStorageUserId                | The string that will represent the userId in the localStorage key related to segments data. (optional) |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ loadDataIntoLocalStorage({
     },
     usingSegmentsCount: 2
   },
-  userId: 'test-visitor-1'
+  userId: 'test-visitor-1',
+  localStorageUserId: 'formatted-visitor'
 })
 // console.log(window.localStorage)
 // {
@@ -41,8 +42,8 @@ loadDataIntoLocalStorage({
 //   "SPLITIO.split.experiment_1": "{ name: 'experiment_1', status: 'foo' }",
 //   "SPLITIO.split.experiment_2": "{ name: 'experiment_2', status: 'bar' }",
 //   "SPLITIO.splits.usingSegments": "2",
-//   "test-visitor-1.SPLITIO.segment.segment_1": "1",
-//   "test-visitor-1.SPLITIO.segment.segment_2": "1"
+//   "formatted-visitor.SPLITIO.segment.segment_1": "1",
+//   "formatted-visitor.SPLITIO.segment.segment_2": "1"
 // }
 ```
 
@@ -65,6 +66,7 @@ The following option properties are available:
 | serializedData.splitsData         | An object of serialized split data you want to cache. (required) |
 | serializedData.usingSegmentsCount | The count of splits using segments. (required) |
 | userId                            | The user id that is a part of an experiment. Either a hashed shopperId or visitorGuid. (required) |
+| localStorageUserId                | The string that will represent the userId in the localStorage key related to segments data. (required) |
 
 ## Testing
 

--- a/src/load-data.js
+++ b/src/load-data.js
@@ -2,7 +2,7 @@
 
 const TILL_KEY = 'SPLITIO.splits.till'
 
-export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '' }, windowLocalStorage = window.localStorage) {
+export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', localStorageUserId = '' }, windowLocalStorage = window.localStorage) {
   if (!('segmentsData' in serializedData) ||
     !('since' in serializedData) ||
     !('splitsData' in serializedData) ||
@@ -31,7 +31,7 @@ export default function loadDataIntoLocalStorage ({ serializedData = {}, userId 
   windowLocalStorage.setItem('SPLITIO.splits.usingSegments', usingSegmentsCount)
   // segmentsData in an object where the property is the segment name and the pertaining value is a stringified object that contains the `added` array of userIds
   Object.keys(segmentsData).forEach(segmentName => {
-    const key = `${userId}.SPLITIO.segment.${segmentName}`
+    const key = `${localStorageUserId}.SPLITIO.segment.${segmentName}`
     const added = JSON.parse(segmentsData[segmentName]).added
     if (added.includes(userId) && windowLocalStorage.getItem(key) !== '1') {
       windowLocalStorage.setItem(key, '1')

--- a/src/load-data.js
+++ b/src/load-data.js
@@ -2,7 +2,7 @@
 
 const TILL_KEY = 'SPLITIO.splits.till'
 
-export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', localStorageUserId = '' }, windowLocalStorage = window.localStorage) {
+export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', localStorageUserId = userId }, windowLocalStorage = window.localStorage) {
   if (!('segmentsData' in serializedData) ||
     !('since' in serializedData) ||
     !('splitsData' in serializedData) ||

--- a/src/load-data.test.js
+++ b/src/load-data.test.js
@@ -84,10 +84,24 @@ describe('lib.load-data.loadDataIntoLocalStorage', () => {
     localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
 
     const serializedData = { segmentsData, since: LARGER_SINCE, splitsData: {}, usingSegmentsCount }
-    loadDataIntoLocalStorage({ serializedData, userId }, localStorageOverride)
+    loadDataIntoLocalStorage({ serializedData, userId, localStorageUserId: userId }, localStorageOverride)
 
     expect(localStorageOverride.setItem.calledWith('SPLITIO.splits.usingSegments', usingSegmentsCount)).to.equal(true)
     expect(localStorageOverride.setItem.calledWith('visitor_guid_1.SPLITIO.segment.segment_1', '1')).to.equal(true)
     expect(localStorageOverride.setItem.calledWith('visitor_guid_1.SPLITIO.segment.segment_2', '1')).to.equal(true)
+  })
+
+  it('should load segments data into localStorage properly with localStorageUserId in key', () => {
+    const localStorageUserId = 'format-visitor'
+    const userId = 'visitor_guid_1'
+    const segmentsData = {
+      segment_1: `{ "name": "segment_1", "added": ["${userId}", "visitor_guid_2"] }`
+    }
+    localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
+
+    const serializedData = { segmentsData, since: LARGER_SINCE, splitsData: {}, usingSegmentsCount: 1 }
+    loadDataIntoLocalStorage({ serializedData, userId, localStorageUserId }, localStorageOverride)
+
+    expect(localStorageOverride.setItem.calledWith(`${localStorageUserId}.SPLITIO.segment.segment_1`, '1')).to.equal(true)
   })
 })


### PR DESCRIPTION
If you don't want to expose a `userId` in a localStorage key, you can pass in an optional `localStorageUserId` parameter.