### PR TITLE
feat: support for optional storagePrefix parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following option properties are available:
 | serializedData.splitsData         | An object of serialized split data you want to cache. (required) |
 | serializedData.usingSegmentsCount | The count of splits using segments. (required) |
 | userId                            | The user id that is a part of an experiment. Either a hashed shopperId or visitorGuid. (required) |
+| storagePrefix                     | An optional parameter that represents the storage.prefix in the [SplitIO configuration](https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#configuration) of the SplitIO factory you are using. |
 
 ## Testing
 

--- a/src/load-data.js
+++ b/src/load-data.js
@@ -3,7 +3,7 @@
 const DEFAULT_LOCALSTORAGE_PREFIX = 'SPLITIO'
 
 export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', storagePrefix = '' }, windowLocalStorage = window.localStorage) {
-  const localStoragePrefix = (storagePrefix) ? `${storagePrefix}.${DEFAULT_LOCALSTORAGE_PREFIX}` : DEFAULT_LOCALSTORAGE_PREFIX
+  const localStoragePrefix = storagePrefix ? `${storagePrefix}.${DEFAULT_LOCALSTORAGE_PREFIX}` : DEFAULT_LOCALSTORAGE_PREFIX
   const tillKey = `${localStoragePrefix}.splits.till`
 
   if (!('segmentsData' in serializedData) ||

--- a/src/load-data.js
+++ b/src/load-data.js
@@ -1,8 +1,11 @@
 'use strict'
 
-const TILL_KEY = 'SPLITIO.splits.till'
+const DEFAULT_LOCALSTORAGE_PREFIX = 'SPLITIO'
 
-export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '' }, windowLocalStorage = window.localStorage) {
+export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', storagePrefix = '' }, windowLocalStorage = window.localStorage) {
+  const localStoragePrefix = (storagePrefix) ? `${storagePrefix}.${DEFAULT_LOCALSTORAGE_PREFIX}` : DEFAULT_LOCALSTORAGE_PREFIX
+  const tillKey = `${localStoragePrefix}.splits.till`
+
   if (!('segmentsData' in serializedData) ||
     !('since' in serializedData) ||
     !('splitsData' in serializedData) ||
@@ -12,26 +15,26 @@ export default function loadDataIntoLocalStorage ({ serializedData = {}, userId 
   const { segmentsData, since, splitsData, usingSegmentsCount } = serializedData
 
   // Do not load data if current localStorage data is more recent
-  if (since <= windowLocalStorage.getItem(TILL_KEY)) {
+  if (since <= windowLocalStorage.getItem(tillKey)) {
     return
   }
   // Split.IO recommends cleaning up the localStorage data
   Object.keys(windowLocalStorage).forEach(key => {
-    if (key.includes('SPLITIO')) {
+    if (key.includes(localStoragePrefix)) {
       windowLocalStorage.removeItem(key)
     }
   })
-  windowLocalStorage.setItem(TILL_KEY, since)
+  windowLocalStorage.setItem(tillKey, since)
 
   // splitsData in an object where the property is the split name and the pertaining value is a stringified json of its data
   Object.keys(splitsData).forEach(splitName => {
-    windowLocalStorage.setItem(`SPLITIO.split.${splitName}`, splitsData[splitName])
+    windowLocalStorage.setItem(`${localStoragePrefix}.split.${splitName}`, splitsData[splitName])
   })
 
-  windowLocalStorage.setItem('SPLITIO.splits.usingSegments', usingSegmentsCount)
+  windowLocalStorage.setItem(`${localStoragePrefix}.splits.usingSegments`, usingSegmentsCount)
   // segmentsData in an object where the property is the segment name and the pertaining value is a stringified object that contains the `added` array of userIds
   Object.keys(segmentsData).forEach(segmentName => {
-    const key = `${userId}.SPLITIO.segment.${segmentName}`
+    const key = `${userId}.${localStoragePrefix}.segment.${segmentName}`
     const added = JSON.parse(segmentsData[segmentName]).added
     if (added.includes(userId) && windowLocalStorage.getItem(key) !== '1') {
       windowLocalStorage.setItem(key, '1')

--- a/src/load-data.js
+++ b/src/load-data.js
@@ -2,7 +2,11 @@
 
 const DEFAULT_LOCALSTORAGE_PREFIX = 'SPLITIO'
 
-export default function loadDataIntoLocalStorage ({ serializedData = {}, userId = '', storagePrefix = '' }, windowLocalStorage = window.localStorage) {
+export default function loadDataIntoLocalStorage ({
+  serializedData = {},
+  userId = '',
+  storagePrefix = ''
+}, windowLocalStorage = window.localStorage) {
   const localStoragePrefix = storagePrefix ? `${storagePrefix}.${DEFAULT_LOCALSTORAGE_PREFIX}` : DEFAULT_LOCALSTORAGE_PREFIX
   const tillKey = `${localStoragePrefix}.splits.till`
 

--- a/src/load-data.test.js
+++ b/src/load-data.test.js
@@ -90,4 +90,27 @@ describe('lib.load-data.loadDataIntoLocalStorage', () => {
     expect(localStorageOverride.setItem.calledWith('visitor_guid_1.SPLITIO.segment.segment_1', '1')).to.equal(true)
     expect(localStorageOverride.setItem.calledWith('visitor_guid_1.SPLITIO.segment.segment_2', '1')).to.equal(true)
   })
+
+  it('should call localStorage properly with storagePrefix passed in', () => {
+    const storagePrefix = 'visitorGuid'
+    const removedItemKey = `${storagePrefix}.SPLITIO.should_be_cleared`
+    localStorageOverride[removedItemKey] = {}
+
+    const splitsData = {
+      experiment_1: 'serialized_experiment_1'
+    }
+    const segmentsData = {
+      segment_1: '{ "name": "segment_1", "added": ["visitor_guid_1", "visitor_guid_2"] }'
+    }
+    localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
+
+    const serializedData = { segmentsData, since: LARGER_SINCE, splitsData, usingSegmentsCount: 1 }
+    loadDataIntoLocalStorage({ serializedData, userId: 'visitor_guid_1', storagePrefix }, localStorageOverride)
+
+    expect(localStorageOverride.removeItem.calledWith(removedItemKey)).to.equal(true)
+    expect(localStorageOverride.setItem.calledWith('visitorGuid.SPLITIO.splits.till', LARGER_SINCE)).to.equal(true)
+    expect(localStorageOverride.setItem.calledWith('visitorGuid.SPLITIO.split.experiment_1', 'serialized_experiment_1')).to.equal(true)
+    expect(localStorageOverride.setItem.calledWith('visitorGuid.SPLITIO.splits.usingSegments', 1)).to.equal(true)
+    expect(localStorageOverride.setItem.calledWith('visitor_guid_1.visitorGuid.SPLITIO.segment.segment_1', '1')).to.equal(true)
+  })
 })


### PR DESCRIPTION
This PR includes a backwards-compatible change that would add an optional parameter, `storagePrefix`.
The use case this is addressing is if you have multiple SplitIO factories in a browser session and want to load data into localStorage for both of these factories without having key collisions.
For this use case, users would have to make sure that the `storagePrefix` matches the `storage.prefix` value they are setting for their [SplitIO factory configuration](https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#configuration).