### PR TITLE
fix(load-data): Set default values for the serialized data

### DIFF
--- a/src/load-data.js
+++ b/src/load-data.js
@@ -10,13 +10,12 @@ export default function loadDataIntoLocalStorage ({
   const localStoragePrefix = storagePrefix ? `${storagePrefix}.${DEFAULT_LOCALSTORAGE_PREFIX}` : DEFAULT_LOCALSTORAGE_PREFIX
   const tillKey = `${localStoragePrefix}.splits.till`
 
-  if (!('segmentsData' in serializedData) ||
-    !('since' in serializedData) ||
-    !('splitsData' in serializedData) ||
-    !('usingSegmentsCount' in serializedData)) {
+  // Do not load data if current serializedData is empty
+  if (Object.keys(serializedData).length === 0) {
     return
   }
-  const { segmentsData, since, splitsData, usingSegmentsCount } = serializedData
+
+  const { segmentsData = {}, since = 0, splitsData = {}, usingSegmentsCount = 0 } = serializedData
 
   // Do not load data if current localStorage data is more recent
   if (since <= windowLocalStorage.getItem(tillKey)) {

--- a/src/load-data.test.js
+++ b/src/load-data.test.js
@@ -20,18 +20,12 @@ describe('lib.load-data.loadDataIntoLocalStorage', () => {
     }
   })
 
-  it('should not affect localStorage if a serializedData property is falsey', () => {
-    const properties = ['segmentsData', 'since', 'splitsData', 'usingSegmentsCount']
-    properties.forEach(property => {
-      delete defaultSerializedData[property]
+  it('should not affect localStorage if serializedData is empty', () => {
+    loadDataIntoLocalStorage({ serializedData: {} }, localStorageOverride)
 
-      loadDataIntoLocalStorage({ serializedData: defaultSerializedData }, localStorageOverride)
-
-      expect(localStorageOverride.getItem.calledOnce).to.equal(false)
-      expect(localStorageOverride.removeItem.called).to.equal(false)
-      expect(localStorageOverride.setItem.called).to.equal(false)
-      defaultSerializedData = Object.assign({}, DEFAULT_SERIALIZED_DATA)
-    })
+    expect(localStorageOverride.getItem.calledOnce).to.equal(false)
+    expect(localStorageOverride.removeItem.called).to.equal(false)
+    expect(localStorageOverride.setItem.called).to.equal(false)
   })
 
   it('should not affect localStorage if its data is more recent', () => {
@@ -68,6 +62,22 @@ describe('lib.load-data.loadDataIntoLocalStorage', () => {
     localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
 
     const serializedData = { segmentsData: {}, since: LARGER_SINCE, splitsData, usingSegmentsCount: 0 }
+    loadDataIntoLocalStorage({ serializedData }, localStorageOverride)
+
+    expect(localStorageOverride.setItem.calledWith('SPLITIO.split.experiment_1', serializedExperimentOne)).to.equal(true)
+    expect(localStorageOverride.setItem.calledWith('SPLITIO.split.experiment_2', serializedExperimentTwo)).to.equal(true)
+  })
+
+  it('should load serialized split data even if segmentsData & usingSegmentsCount are empty', () => {
+    const serializedExperimentOne = 'serialized_experiment_1'
+    const serializedExperimentTwo = 'serialized_experiment_2'
+    const splitsData = {
+      experiment_1: serializedExperimentOne,
+      experiment_2: serializedExperimentTwo
+    }
+    localStorageOverride.getItem.onFirstCall().returns(SMALLER_SINCE)
+
+    const serializedData = { since: LARGER_SINCE, splitsData }
     loadDataIntoLocalStorage({ serializedData }, localStorageOverride)
 
     expect(localStorageOverride.setItem.calledWith('SPLITIO.split.experiment_1', serializedExperimentOne)).to.equal(true)


### PR DESCRIPTION
Since this change in the split-node-serializer https://github.com/godaddy/split-node-serializer/commit/267a6c900140428d9d5355637d6d5a5e1ea37ff2 we have not returned key values if they are not present in the cache. This happens in practical use cases like when segmentData is turned off in the hivemind SDK's. We still want to load data into localstorage in these cases.